### PR TITLE
Update notification.blade.php

### DIFF
--- a/packages/notifications/resources/views/notification.blade.php
+++ b/packages/notifications/resources/views/notification.blade.php
@@ -84,7 +84,7 @@
 
             @if (filled($body = $getBody()))
                 <x-filament-notifications::body class="mt-1">
-                    {{ str($body)->sanitizeHtml()->toHtmlString() }}
+                    {{ str($body)->markdown()->sanitizeHtml()->toHtmlString() }}
                 </x-filament-notifications::body>
             @endif
 


### PR DESCRIPTION
add the missing markdown support to filament notifications.

The documentation for filament notifications says, the body supports markdown. this is clearly not the case. this PR closes this gap. see https://filamentphp.com/docs/3.x/notifications/sending-notifications#setting-body-text

- [x] Changes have been thoroughly tested to not break existing functionality.
- [ ] New functionality has been documented or existing documentation has been updated to reflect changes.
- [ ] Visual changes are explained in the PR description using a screenshot/recording of before and after.
